### PR TITLE
fix: resolve deprecated notices and warnings in recent PHP versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,100 @@
-FluxCP
-======
+# FluxCP - Hercules Version
 
-Flux Control Panel (FluxCP) for Hercules server.
+FluxCP is a **web-based control panel** for managing [Hercules](https://github.com/HerculesWS/Hercules) servers.
+It allows players to register accounts, view server stats, rankings, and provides administrative tools for GMs.
 
-Requirements
----------
-* PHP 5.2
-* PDO and PDO-MYSQL extensions for PHP5 (including PHP_MYSQL support)
-* MySQL 5
-* Optional: GD2 (for guild emblems and registration CAPTCHA)
-* Optional: Tidy (for cleaner HTML output)
-* Optional: mod_rewrite support for UseCleanUrls feature
+---
 
-Authors
----------
-The following people have contributed to the development of FluxCP through the years.
+## 📋 Requirements
 
-Thank you for all your hard work.
+- **PHP 7.0+**
+- **MySQL 5.x+**
+- **PHP extensions**:
+  - `PDO` and `PDO_MYSQL`
+  - `GD2` (optional – for displaying guild emblems and CAPTCHA)
+  - `Tidy` (optional – for cleaner HTML output)
+- **Apache (recommended)** with:
+  - `mod_rewrite` enabled (optional – for UseCleanUrls feature)
 
-* Boooo
-* Byteflux86
-* Gepard
-* hemagx
-* jaBote
-* Mumbles
-* Mysterious
-* Paradox924X
-* shugotenshi
-* Streusel
-* Xantara
+---
+
+## ⚙️ Installation Guide
+
+1. **Download and extract FluxCP** to your web server directory (e.g. `public_html/`, `www/` or `htdocs`):
+
+```bash
+git clone https://github.com/HerculesWS/FluxCP.git
+```
+
+2. **Create a database** for your control panel (separate from your main RO databases, optional but recommended).
+
+3. **Edit the application configuration**:
+
+   Open the file `config/application.php` and configure the following:
+```php
+  'ServerAddress'      => 'mysite.com',
+  'BaseURI'            => '',
+  'InstallerPassword'  => 'InstallPasswordHere',
+```
+   - `ServerAddress` with your domain, e.g., `mysite.com`
+   - `BaseURI` only if the files are not in the web server root, e.g., `/site` or `/painel`
+   - `InstallerPassword` with a secure password for the installation page
+   - `ThemeName` (optional) if using custom themes; add your theme to the array
+
+   **PayPal setup (optional):**
+   - `DonationCurrency` with the currency code, e.g., `USD` for US dollars
+   - `AcceptDonations` must be set to `true`
+   - `PayPalBusinessEmail` with your PayPal account email
+
+4. **Configure the server and database connection**:
+
+   Open the file `config/servers.php` and set:
+```php
+'ServerName'     => 'FluxRO',
+'DbConfig'       => array(
+     ...
+    'Hostname'   => '127.0.0.1',
+    'Username'   => 'ragnarok',
+    'Password'   => 'ragnarok',
+    'Database'   => 'ragnarok',
+     ...
+'LogsDbConfig'   => array(
+     ...
+    'Username'   => 'ragnarok_log',
+    'Password'   => 'ragnarok_log',
+    'Database'   => 'ragnarok_log',
+    ...
+```
+   - `ServerName` with the name of your server
+   - Under `DbConfig` and `LogsDbConfig`, set `hostname`, `username`, `password`, and `database` with the correct access credentials. If FluxCP uses the same database as your emulator, the values will likely be similar.
+   - In `LoginServer`, update `Address` and `Port` with the correct login server details
+   - In `CharMapServers`, update:
+     - `ServerName` with your server's name
+     - `Renewal` to `true` and `PreRenewal` to `false`
+     - `ExpRates` and `DropRates` if using FluxCP's web database
+     - `CharServer` and `MapServer` with the correct `Address` and `Port`
+
+5. **Point your browser** to the folder where FluxCP is installed and follow the web-based installer steps.
+
+6. **Done!** You should now be able to access your FluxCP panel.
+
+---
+
+## 👥 Contributors
+
+The following people have contributed to the development of FluxCP over the years.
+Thank you for your hard work and dedication!
+
+|# |# |# |
+|---|---|---|
+| Boooo        | Byteflux86   | Gepard     |
+| hemagx       | jaBote       | Mumbles    |
+| Mysterious   | Paradox924X  | shugotenshi |
+| Streusel     | Xantara      |            |
+
+
+---
+
+## 📄 License
+
+FluxCP is released under the terms of the LGPL-3.0 License.

--- a/lib/Flux/Config.php
+++ b/lib/Flux/Config.php
@@ -15,7 +15,7 @@ class Flux_Config {
 	 * @var array
 	 */
 	private $configArr;
-	
+
 	/**
 	 * Default options for setter.
 	 *
@@ -23,7 +23,7 @@ class Flux_Config {
 	 * @var array
 	 */
 	private $defaultSetOptions = array('overwrite' => true, 'force' => true);
-	
+
 	/**
 	 * This is here for any developer's convenience, just in case he/she would
 	 * like to re-use this library without having to depend on the Flux_Error
@@ -37,7 +37,7 @@ class Flux_Config {
 	 * @var string
 	 */
 	private $exceptionClass = 'Flux_Error';
-	
+
 	/**
 	 * Construct a Flux_Config instance which acts as a more convenient
 	 * accessor to the specified configuration array.
@@ -49,7 +49,7 @@ class Flux_Config {
 	{
 		$this->configArr = &$configArr;
 	}
-	
+
 	/**
 	 * This is here... for no real GOOD reason, but should the need arise, at
 	 * least you aren't deprived of access to it.
@@ -61,7 +61,7 @@ class Flux_Config {
 	{
 		return $this->configArr;
 	}
-	
+
 	/**
 	 * Goes through each child in the array which is also an array, and returns
 	 * them collectively as an array of Flux_Config instances.
@@ -79,7 +79,7 @@ class Flux_Config {
 		}
 		return $children;
 	}
-	
+
 	/**
 	 * Get the value held by the specified key. If the value is an array it
 	 * will be returned as an instance of Flux_Config by default, unless
@@ -94,10 +94,10 @@ class Flux_Config {
 	 */
 	public function get($key, $configObjectIfArray = true)
 	{
-		$keys = explode('.', $key);
+		$keys = explode('.', $key ?? '');
 		$base = &$this->configArr;
 		$size = count($keys) - 1;
-		
+
 		for ($i = 0; $i < $size; ++$i) {
 			$currentKey = $keys[$i];
 			if (is_array($base) && array_key_exists($currentKey, $base)) {
@@ -108,7 +108,7 @@ class Flux_Config {
 				return null;
 			}
 		}
-		
+
 		$currentKey = $keys[$size];
 		if (array_key_exists($currentKey, $base)) {
 			$value = &$base[$currentKey];
@@ -130,7 +130,7 @@ class Flux_Config {
 			return null;
 		}
 	}
-	
+
 	/**
 	 * Set a key to hold the specified value. The format for specifying a key
 	 * is 100% identical to Flux_Config::get().
@@ -150,7 +150,7 @@ class Flux_Config {
 		$keys = explode('.', $key);
 		$base = &$this->configArr;
 		$size = count($keys) - 1;
-		
+
 		for ($i = 0; $i < $size; ++$i) {
 			$currentKey = $keys[$i];
 			if (is_array($base) && array_key_exists($currentKey, $base)) {
@@ -165,16 +165,16 @@ class Flux_Config {
 				return false;
 			}
 		}
-		
+
 		$currentKey = $keys[$size];
 		if (array_key_exists($currentKey, $base) && !$opts['overwrite']) {
 			return false;
 		}
-		
+
 		$base[$currentKey] = $value;
 		return $value;
 	}
-	
+
 	/**
 	 * Convenience method for raising an internal exception.
 	 *
@@ -186,7 +186,7 @@ class Flux_Config {
 		$exceptionClass = $this->exceptionClass;
 		throw new $exceptionClass($message);
 	}
-	
+
 	/**
 	 * Adds the ability to call set<ConfigDirective>(<Value>) as native methods.
 	 *
@@ -212,7 +212,7 @@ class Flux_Config {
 			return $this->set($m[1], $args[0], $options);
 		}
 	}
-	
+
 	/**
 	 *
 	 */

--- a/lib/Flux/Template.php
+++ b/lib/Flux/Template.php
@@ -22,7 +22,7 @@ class Flux_Template {
 	 * @var array
 	 */
 	private $defaultData = array();
-	
+
 	/**
 	 * Request parameters.
 	 *
@@ -30,7 +30,7 @@ class Flux_Template {
 	 * @var Flux_Config
 	 */
 	protected $params;
-	
+
 	/**
 	 * Base URI of the entire application.
 	 *
@@ -38,7 +38,7 @@ class Flux_Template {
 	 * @var string
 	 */
 	protected $basePath;
-	
+
 	/**
 	 * Module path.
 	 *
@@ -46,7 +46,7 @@ class Flux_Template {
 	 * @var string
 	 */
 	protected $modulePath;
-	
+
 	/**
 	 * Module name.
 	 *
@@ -54,7 +54,7 @@ class Flux_Template {
 	 * @var string
 	 */
 	protected $moduleName;
-	
+
 	/**
 	 * Theme path.
 	 *
@@ -62,7 +62,7 @@ class Flux_Template {
 	 * @var string
 	 */
 	protected $themePath;
-	
+
 	/**
 	 * Theme name.
 	 *
@@ -70,7 +70,7 @@ class Flux_Template {
 	 * @var string
 	 */
 	protected $themeName;
-	
+
 	/**
 	 * Action name. Actions exist as modulePath/moduleName/actionName.php.
 	 *
@@ -78,7 +78,7 @@ class Flux_Template {
 	 * @var string
 	 */
 	protected $actionName;
-	
+
 	/**
 	 * Action path, would be the path format documented in $actionName.
 	 *
@@ -86,7 +86,7 @@ class Flux_Template {
 	 * @var string
 	 */
 	protected $actionPath;
-	
+
 	/**
 	 * View name, this is usually the same as the actionName.
 	 *
@@ -94,7 +94,7 @@ class Flux_Template {
 	 * @var string
 	 */
 	protected $viewName;
-	
+
 	/**
 	 * View path, follows a similar (or rather, exact) format like actionPath,
 	 * except there would be a themePath and viewName instead.
@@ -103,7 +103,7 @@ class Flux_Template {
 	 * @var string
 	 */
 	protected $viewPath;
-	
+
 	/**
 	 * Header name. The header file would exist under the themePath's top level
 	 * and the headerName would simply be the file's basename without the .php
@@ -111,9 +111,9 @@ class Flux_Template {
 	 *
 	 * @access protected
 	 * @var string
-	 */	
+	 */
 	protected $headerName;
-	
+
 	/**
 	 * The actual path to the header file.
 	 *
@@ -121,7 +121,7 @@ class Flux_Template {
 	 * @var string
 	 */
 	protected $headerPath;
-	
+
 	/**
 	 * The footer name.
 	 * Similar to headerName. This name is usually 'footer'.
@@ -130,7 +130,7 @@ class Flux_Template {
 	 * @var string
 	 */
 	protected $footerName;
-	
+
 	/**
 	 * The actual path to the footer file.
 	 *
@@ -138,7 +138,7 @@ class Flux_Template {
 	 * @var string
 	 */
 	protected $footerPath;
-	
+
 	/**
 	 * Whether or not to use mod_rewrite-powered clean URLs or just plain old
 	 * query strings.
@@ -147,7 +147,7 @@ class Flux_Template {
 	 * @var string
 	 */
 	protected $useCleanUrls;
-	
+
 	/**
 	 * URL of the current module/action being viewed.
 	 *
@@ -155,7 +155,7 @@ class Flux_Template {
 	 * @var string
 	 */
 	protected $url;
-	
+
 	/**
 	 * URL of the current module/action being viewed. (including query string)
 	 *
@@ -164,7 +164,7 @@ class Flux_Template {
 	 */
 	protected $urlWithQs;
 	protected $urlWithQS; // compatibility.
-	
+
 	/**
 	 * Module/action for missing action's event.
 	 *
@@ -172,7 +172,7 @@ class Flux_Template {
 	 * @var array
 	 */
 	protected $missingActionModuleAction;
-	
+
 	/**
 	 * Module/action for missing view's event.
 	 *
@@ -180,7 +180,7 @@ class Flux_Template {
 	 * @var array
 	 */
 	protected $missingViewModuleAction;
-	
+
 	/**
 	 * Inherit view / controllers from another theme ?
 	 *
@@ -188,7 +188,7 @@ class Flux_Template {
 	 * @var Flux_Template
 	 */
 	public $parentTemplate;
-	
+
 	/**
 	 * List of themes loaded, use for avoid circular dependencies
 	 *
@@ -196,7 +196,7 @@ class Flux_Template {
 	 * @var array
 	 */
 	static public $themeLoaded = array();
-	
+
 	/**
 	 * HTTP referer.
 	 *
@@ -204,7 +204,7 @@ class Flux_Template {
 	 * @var string
 	 */
 	public $referer;
-	
+
 	/**
 	 * Construct new template onbject.
 	 *
@@ -246,7 +246,7 @@ class Flux_Template {
 		}
 
 	}
-	
+
 	/**
 	 * Any data that gets set here will be available to all templates as global
 	 * variables unless they are overridden by variables of the same name set
@@ -260,7 +260,7 @@ class Flux_Template {
 		$this->defaultData = $data;
 		return $data;
 	}
-	
+
 	/**
 	 * Render a template, but before doing so, call the action file and render
 	 * the header->view->footer in that order.
@@ -277,10 +277,10 @@ class Flux_Template {
 			ini_set('zlib.output_compression', 'On');
 			ini_set('zlib.output_compression_level', (int)Flux::config('GzipCompressionLevel'));
 		}
-		
+
 		$addon = false;
 		$this->actionPath = sprintf('%s/%s/%s.php', $this->modulePath, $this->moduleName, $this->actionName);
-		
+
 		if (!file_exists($this->actionPath)) {
 			foreach (Flux::$addons as $_tmpAddon) {
 				if ($_tmpAddon->respondsTo($this->moduleName, $this->actionName)) {
@@ -288,7 +288,7 @@ class Flux_Template {
 					$this->actionPath = sprintf('%s/%s/%s.php', $addon->moduleDir, $this->moduleName, $this->actionName);
 				}
 			}
-			
+
 			if (!$addon) {
 				$this->moduleName = $this->missingActionModuleAction[0];
 				$this->actionName = $this->missingActionModuleAction[1];
@@ -296,12 +296,12 @@ class Flux_Template {
 				$this->actionPath = sprintf('%s/%s/%s.php', $this->modulePath, $this->moduleName, $this->actionName);
 			}
 		}
-		
+
 		$this->viewPath = $this->themePath(sprintf('%s/%s.php', $this->moduleName, $this->actionName), true);
-		
+
 		if (!file_exists($this->viewPath) && $addon) {
 			$this->viewPath = $addon->getView( $this, $this->moduleName, $this->actionName);
-			
+
 			if ( $this->viewPath === false ) {
 				$this->moduleName = $this->missingViewModuleAction[0];
 				$this->actionName = $this->missingViewModuleAction[1];
@@ -310,12 +310,12 @@ class Flux_Template {
 				$this->viewPath   = $this->themePath(sprintf('%s/%s.php', $this->moduleName, $this->viewName), true);
 			}
 		}
-		
+
 		$this->headerPath = $this->themePath($this->headerName.'.php', true);
 		$this->footerPath = $this->themePath($this->footerName.'.php', true);
 		$this->url        = $this->url($this->moduleName, $this->actionName);
 		$this->urlWithQS  = $this->url;
-		
+
 		if (!empty($_SERVER['QUERY_STRING'])) {
 			if ($this->useCleanUrls) {
 				$this->urlWithQS .= "?{$_SERVER['QUERY_STRING']}";
@@ -325,17 +325,17 @@ class Flux_Template {
 					list ($key,$val) = explode('=', $line, 2);
 					$key = urldecode($key);
 					$val = urldecode($val);
-					
+
 					if ($key != 'module' && $key != 'action') {
 						$this->urlWithQS .= sprintf('&%s=%s', urlencode($key), urlencode($val));
 					}
 				}
 			}
 		}
-		
+
 		// Compatibility.
 		$this->urlWithQs  = $this->urlWithQS;
-		
+
 		// Tidy up!
 		if (Flux::config('OutputCleanHTML')) {
 			$dispatcher = Flux_Dispatcher::getInstance();
@@ -356,34 +356,34 @@ class Flux_Template {
 				ob_start();
 			}
 		}
-		
+
 		// Merge with default data.
 		$data = array_merge($this->defaultData, $dataArr);
-		
+
 		// Extract data array and make them appear as though they were global
 		// variables from the template.
 		extract($data, EXTR_REFS);
-		
+
 		// Files object.
 		$files = new Flux_Config($_FILES);
-		
+
 		$preprocessorPath = sprintf('%s/main/preprocess.php', $this->modulePath);
 		if (file_exists($preprocessorPath)) {
 			include $preprocessorPath;
 		}
-		
+
 		include $this->actionPath;
-		
+
 		$pageMenuFile   = FLUX_ROOT."/modules/{$this->moduleName}/pagemenu/{$this->actionName}.php";
 		$pageMenuItems  = array();
-		
+
 		// Get the main menu file first (located in the actual module).
 		if (file_exists($pageMenuFile)) {
 			ob_start();
 			$pageMenuItems = include $pageMenuFile;
 			ob_end_clean();
 		}
-		
+
 		$addonPageMenuFiles = glob(FLUX_ADDON_DIR."/*/modules/{$this->moduleName}/pagemenu/{$this->actionName}.php");
 		if ($addonPageMenuFiles) {
 			foreach ($addonPageMenuFiles as $addonPageMenuFile) {
@@ -392,17 +392,17 @@ class Flux_Template {
 				ob_end_clean();
 			}
 		}
-		
+
 		if (file_exists($this->headerPath)) {
 			include $this->headerPath;
 		}
-	
+
 		include $this->viewPath;
-	
+
 		if (file_exists($this->footerPath)) {
 			include $this->footerPath;
 		}
-		
+
 		// Really, tidy up!
 		if (Flux::config('OutputCleanHTML') && !$tidyIgnore && function_exists('tidy_repair_string')) {
 			$content = ob_get_clean();
@@ -410,7 +410,7 @@ class Flux_Template {
 			echo $content;
 		}
 	}
-	
+
 	/**
 	 * Returns an array of menu items that should be diplayed from the theme.
 	 * Only menu items the current user (and their group level) have access to
@@ -426,11 +426,11 @@ class Flux_Template {
 		$defaultAction     = Flux_Dispatcher::getInstance()->defaultAction;
 		$menuItems         = Flux::config('MenuItems');
 		$allowedItems      = array();
-		
+
 		if (!($menuItems instanceOf Flux_Config)) {
 			return array();
 		}
-		
+
 		foreach ($menuItems->toArray() as $categoryName => $menu) {
 			foreach ($menu as $menuName => $menuItem) {
 				$module = array_key_exists('module', $menuItem) ? $menuItem['module'] : false;
@@ -452,7 +452,7 @@ class Flux_Template {
 					if (empty($allowedItems[$categoryName])) {
 						$allowedItems[$categoryName] = array();
 					}
-					
+
 					if ($exturl) {
 						$allowedItems[$categoryName][] = array(
 							'name'   => $menuName,
@@ -474,10 +474,10 @@ class Flux_Template {
 				}
 			}
 		}
-		
+
 		return $allowedItems;
 	}
-	
+
 	/**
 	 * @see Flux_Template::getMenuItems()
 	 */
@@ -485,7 +485,7 @@ class Flux_Template {
 	{
 		return $this->getMenuItems(true);
 	}
-	
+
 	/**
 	 * Get sub-menu items for a particular module.
 	 *
@@ -498,20 +498,20 @@ class Flux_Template {
 		$moduleName   = $moduleName ? $moduleName : $this->moduleName;
 		$subMenuItems = Flux::config('SubMenuItems');
 		$allowedItems = array();
-		
+
 		if (!($subMenuItems instanceOf Flux_Config) || !( ($menus = $subMenuItems->get($moduleName)) instanceOf Flux_Config )) {
 			return array();
 		}
-		
+
 		foreach ($menus->toArray() as $actionName => $menuName) {
 			if ($auth->actionAllowed($moduleName, $actionName)) {
 				$allowedItems[] = array('name' => $menuName, 'module' => $moduleName, 'action' => $actionName);
 			}
 		}
-		
+
 		return $allowedItems;
 	}
-	
+
 	/**
 	 * Get an array of login server names.
 	 *
@@ -521,7 +521,7 @@ class Flux_Template {
 	{
 		return array_keys(Flux::$loginAthenaGroupRegistry);
 	}
-	
+
 	/**
 	 * Determine if more than 1 server exists.
 	 *
@@ -531,7 +531,7 @@ class Flux_Template {
 	{
 		return count(Flux::$loginAthenaGroupRegistry) > 1;
 	}
-	
+
 	/**
 	 * Obtain the absolute web path of the specified user path. Specify the
 	 * path as a relative path.
@@ -551,7 +551,7 @@ class Flux_Template {
 		}
 
 		return preg_replace('&/{2,}&', '/', $path);	}
-	
+
 	/**
 	 * Similar to the path() method, but uses the $themePath as the path from
 	 * which the user-specified path is relative.
@@ -577,7 +577,7 @@ class Flux_Template {
 		$uri  = $this->path("{$this->themePath}/{$this->themeName}/{$path}", $included);
 
 		// normalized basePath.
-		$base = preg_replace('/(\/+)$/', '', $this->basePath ) . '/'; 
+		$base = preg_replace('/(\/+)$/', '', $this->basePath ) . '/';
 		$base = preg_quote( $base, '/' );
 		$chk  = FLUX_ROOT .'/'. preg_replace('/^('.$base.')/', '', $uri );
 
@@ -593,7 +593,7 @@ class Flux_Template {
 
 		return $uri . $frag;
 	}
-	
+
 	/**
 	 * Create a URI based on the setting of $useCleanUrls. This will determine
 	 * whether or not we will create a mod_rewrite-based clean URL or just a
@@ -608,15 +608,15 @@ class Flux_Template {
 		$defaultAction  = Flux_Dispatcher::getInstance()->defaultAction;
 		$serverProtocol = '';
 		$serverAddress  = '';
-		
+
 		if ($params instanceOf Flux_Config) {
 			$params = $params->toArray();
 		}
-		
+
 		if (array_key_exists('_host', $params)) {
 			$_host  = $params['_host'];
 			$_https = false;
-			
+
 			if ($_host && ($addr=Flux::config('ServerAddress'))) {
 				if (array_key_exists('_https', $params)) {
 					$_https = $params['_https'];
@@ -631,24 +631,24 @@ class Flux_Template {
 				$serverProtocol = $_https ? 'https://' : 'http://';
 				$serverAddress  = $addr;
 			}
-			
+
 			unset($params['_host']);
-			
+
 			if (array_key_exists('_https', $params)) {
 				unset($params['_https']);
 			}
 		}
-		
+
 		$queryString = '';
-		
+
 		if (count($params)) {
 			$queryString .= Flux::config('UseCleanUrls') ? '?' : '&';
 			foreach ($params as $param => $value) {
-				$queryString .= sprintf('%s=%s&', $param, urlencode($value));
+				$queryString .= sprintf('%s=%s&', $param, urlencode($value ?? ''));
 			}
 			$queryString = rtrim($queryString, '&');
 		}
-		
+
 		if ($this->useCleanUrls) {
 			if ($actionName && $actionName != $defaultAction) {
 				$url = sprintf('%s/%s/%s/%s', $this->basePath, $moduleName, $actionName, $queryString);
@@ -667,7 +667,7 @@ class Flux_Template {
 		}
 		return $serverProtocol.preg_replace('&/{2,}&', '/', "$serverAddress/$url");
 	}
-	
+
 	/**
 	 * Format currency strings.
 	 *
@@ -685,7 +685,7 @@ class Flux_Template {
 		);
 		return $amount;
 	}
-	
+
 	/**
 	 * Format a MySQL DATE column according to the DateFormat config.
 	 *
@@ -698,7 +698,7 @@ class Flux_Template {
 		$ts = $date ? strtotime($date) : time();
 		return date(Flux::config('DateFormat'), $ts);
 	}
-	
+
 	/**
 	 * Format a MySQL DATETIME column according to the DateTimeFormat config.
 	 *
@@ -711,7 +711,7 @@ class Flux_Template {
 		$ts = $dateTime ? strtotime($dateTime) : time();
 		return date(Flux::config('DateTimeFormat'), $ts);
 	}
-	
+
 	/**
 	 * Create a series of select fields matching a MySQL DATE format.
 	 *
@@ -729,14 +729,14 @@ class Flux_Template {
 		if(!isset($backwardYears)) {
 			$backwardYears = (int)Flux::config('BackwardYears');
 		}
-		
+
 		$ts    = $value && !preg_match('/^0000-00-00(?: 00:00:00)?$/', $value) ? strtotime($value) : time();
 		$year  = ($year =$this->params->get("{$name}_year"))  ? $year  : date('Y', $ts);
 		$month = ($month=$this->params->get("{$name}_month")) ? $month : date('m', $ts);
 		$day   = ($day  =$this->params->get("{$name}_day"))   ? $day   : date('d', $ts);
 		$fw    = $year + $fowardYears;
 		$bw    = $year - $backwardYears;
-		
+
 		// Get years.
 		$years = sprintf('<select name="%s_year">', $name);
 		for ($i = $fw; $i >= $bw; --$i) {
@@ -748,7 +748,7 @@ class Flux_Template {
 			}
 		}
 		$years .= '</select>';
-		
+
 		// Get months.
 		$months = sprintf('<select name="%s_month">', $name);
 		for ($i = 1; $i <= 12; ++$i) {
@@ -760,7 +760,7 @@ class Flux_Template {
 			}
 		}
 		$months .= '</select>';
-		
+
 		// Get days.
 		$days = sprintf('<select name="%s_day">', $name);
 		for ($i = 1; $i <= 31; ++$i) {
@@ -772,10 +772,10 @@ class Flux_Template {
 			}
 		}
 		$days .= '</select>';
-		
+
 		return sprintf('<span class="date-field">%s-%s-%s</span>', $years, $months, $days);
 	}
-	
+
 	/**
 	 * Create a series of select fields matching a MySQL DATETIME format.
 	 *
@@ -791,7 +791,7 @@ class Flux_Template {
 		$hour      = date('H', $ts);
 		$minute    = date('i', $ts);
 		$second    = date('s', $ts);
-		
+
 		// Get hours.
 		$hours = sprintf('<select name="%s_hour">', $name);
 		for ($i = 0; $i <= 23; ++$i) {
@@ -803,7 +803,7 @@ class Flux_Template {
 			}
 		}
 		$hours .= '</select>';
-		
+
 		// Get minutes.
 		$minutes = sprintf('<select name="%s_minute">', $name);
 		for ($i = 0; $i <= 59; ++$i) {
@@ -815,7 +815,7 @@ class Flux_Template {
 			}
 		}
 		$minutes .= '</select>';
-		
+
 		// Get seconds.
 		$seconds = sprintf('<select name="%s_second">', $name);
 		for ($i = 0; $i <= 59; ++$i) {
@@ -827,10 +827,10 @@ class Flux_Template {
 			}
 		}
 		$seconds .= '</select>';
-		
+
 		return sprintf('<span class="date-time-field">%s @ %s:%s:%s</span>', $dateField, $hours, $minutes, $seconds);
 	}
-	
+
 	/**
 	 * Returns "up" or "down" in a span HTML element with either the class
 	 * .up or .down, based on the value of $bool. True returns up, false
@@ -844,7 +844,7 @@ class Flux_Template {
 		$class = $bool ? 'up' : 'down';
 		return sprintf('<span class="%s">%s</span>', $class, $bool ? 'Online' : 'Offline');
 	}
-	
+
 	/**
 	 * Redirect client to another location. Script execution is terminated
 	 * after instructing the client to redirect.
@@ -856,11 +856,11 @@ class Flux_Template {
 		if (is_null($location)) {
 			$location = $this->basePath;
 		}
-		
+
 		header("Location: $location");
 		exit;
 	}
-	
+
 	/**
 	 * Guess the HTTP server's current full URL.
 	 *
@@ -872,18 +872,18 @@ class Flux_Template {
 		$proto    = empty($_SERVER['HTTPS']) || $_SERVER['HTTPS'] === "off" ? 'http://' : 'https://';
 		$hostname = empty($_SERVER['HTTP_HOST']) ? $_SERVER['SERVER_NAME'] : $_SERVER['HTTP_HOST'];
 		$request  = $_SERVER['REQUEST_URI'];
-		
+
 		if ($withRequest) {
 			$url = $proto.$hostname.$request;
 		}
 		else {
 			$url = $proto.$hostname.'/'.$this->basePath;
 		}
-		
+
 		$url = rtrim(preg_replace('&/{2,}&', '/', $url), '/');
 		return $url;
 	}
-	
+
 	/**
 	 * Convenience method for retrieving a paginator instance.
 	 *
@@ -897,7 +897,7 @@ class Flux_Template {
 		$paginator = new Flux_Paginator($total, $this->url($this->moduleName, $this->actionName, array('_host' => false)), $options);
 		return $paginator;
 	}
-	
+
 	/**
 	 * Link to an account view page.
 	 *
@@ -916,7 +916,7 @@ class Flux_Template {
 			return false;
 		}
 	}
-	
+
 	/**
 	 * Link to an account search.
 	 *
@@ -935,7 +935,7 @@ class Flux_Template {
 			return false;
 		}
 	}
-	
+
 	/**
 	 * Link to a character view page.
 	 *
@@ -951,7 +951,7 @@ class Flux_Template {
 			if ($server) {
 				$params['preferred_server'] = $server;
 			}
-			
+
 			$url = $this->url('character', 'view', $params);
 			return sprintf('<a href="%s" class="link-to-character">%s</a>', $url, htmlspecialchars($text));
 		}
@@ -959,7 +959,7 @@ class Flux_Template {
 			return false;
 		}
 	}
-	
+
 	/**
 	 * Deny entry to a page if called. This method should be used from a module
 	 * script, and no where else.
@@ -969,7 +969,7 @@ class Flux_Template {
 		$location = $this->url('unauthorized');
 		$this->redirect($location);
 	}
-	
+
 	/**
 	 * Get the full gender string from a gender letter (e.g. M for Male).
 	 *
@@ -994,7 +994,7 @@ class Flux_Template {
 				break;
 		}
 	}
-	
+
 	/**
 	 * Get the account state name corresponding to the state number.
 	 *
@@ -1006,7 +1006,7 @@ class Flux_Template {
 	{
 		$text  = false;
 		$state = (int)$state;
-		
+
 		switch ($state) {
 			case 0:
 				$text  = Flux::message('AccountStateNormal');
@@ -1017,7 +1017,7 @@ class Flux_Template {
 				$class = 'state-permanently-banned';
 				break;
 		}
-		
+
 		if ($text) {
 			$text = htmlspecialchars($text);
 			return sprintf('<span class="account-state %s">%s<span>', $class, $text);
@@ -1026,7 +1026,7 @@ class Flux_Template {
 			return false;
 		}
 	}
-	
+
 	/**
 	 * Get the job class name from a job ID.
 	 *
@@ -1038,7 +1038,7 @@ class Flux_Template {
 	{
 		return Flux::getJobClass($id);
 	}
-	
+
 	/**
 	 * Return hidden input fields containing module and action names based on
 	 * the setting of UseCleanUrls.
@@ -1049,7 +1049,7 @@ class Flux_Template {
 	 * @access public
 	 */
 	public function moduleActionFormInputs($moduleName, $actionName = null)
-	{	
+	{
 		$inputs = '';
 		if (!Flux::config('UseCleanUrls')) {
 			if (!$actionName) {
@@ -1061,7 +1061,7 @@ class Flux_Template {
 		}
 		return $inputs;
 	}
-	
+
 	/**
 	 * Get the homun class name from a class ID.
 	 *
@@ -1086,7 +1086,7 @@ class Flux_Template {
 	{
 		return Flux::getItemType($id, $id2);
 	}
-	
+
 	/**
 	 * Get the item information from splitting a delimiter
 	 * Used for renewal ATK and MATK as well as equip_level_min and equip_level_max.
@@ -1107,7 +1107,7 @@ class Flux_Template {
 		}
 		return $object;
 	}
-	
+
 	/**
 	 * Get the equip location combination name from an equip location combination.
 	 *
@@ -1119,7 +1119,7 @@ class Flux_Template {
 	{
 		return Flux::getEquipLocationCombination($id);
 	}
-	
+
 	/**
 	 *
 	 *
@@ -1129,15 +1129,15 @@ class Flux_Template {
 		if (!$serverName) {
 			$serverName = Flux::$sessionData->loginAthenaGroup->serverName;
 		}
-		
+
 		if (!$athenaServerName) {
 			$athenaServerName = Flux::$sessionData->getAthenaServer(Flux::$sessionData->athenaServerName);
 		}
-		
+
 		return $this->url('guild', 'emblem',
 			array('login' => $serverName, 'charmap' => $athenaServerName, 'id' => $guildID));
 	}
-	
+
 	/**
 	 * Redirect to login page if the user is not currently logged in.
 	 */
@@ -1146,7 +1146,7 @@ class Flux_Template {
 		$dispatcher = Flux_Dispatcher::getInstance();
 		$dispatcher->loginRequired($this->basePath, $message);
 	}
-	
+
 	/**
 	 * Link to a item view page.
 	 *
@@ -1162,7 +1162,7 @@ class Flux_Template {
 			if ($server) {
 				$params['preferred_server'] = $server;
 			}
-			
+
 			$url = $this->url('item', 'view', $params);
 			return sprintf('<a href="%s" class="link-to-item">%s</a>', $url, htmlspecialchars($text));
 		}
@@ -1170,7 +1170,7 @@ class Flux_Template {
 			return false;
 		}
 	}
-	
+
 	/**
 	 *
 	 */
@@ -1179,17 +1179,17 @@ class Flux_Template {
 		$lines  = preg_split('/(\r?\n)/', $scriptText, -1);
 		$text   = '';
 		$script = array();
-		
+
 		foreach ($lines as $num => $line) {
 			$text    .= "$line\n";
 			$lineNum  = sprintf('<span class="script-line-num">%d</span>', $num + 1);
 			$lineCode = sprintf('<span class="script-line-code">%s</span>', htmlspecialchars($line));
 			$script[] = sprintf('<p class="script-line">%s %s</p>', $lineNum, $lineCode);
 		}
-		
+
 		return trim($text) == '' ? '' : implode("\n", $script);
 	}
-	
+
 	/**
 	 *
 	 */
@@ -1209,7 +1209,7 @@ class Flux_Template {
 			return Flux::message('UnknownLabel');
 		}
 	}
-	
+
 	/**
 	 *
 	 */
@@ -1218,13 +1218,13 @@ class Flux_Template {
 		$jobs      = array();
 		$equipJob  = (int)$equipJob;
 		$equipJobs = Flux::getEquipJobsList();
-		
+
 		foreach ($equipJobs as $bit => $name) {
 			if ($equipJob & $bit) {
 				$jobs[] = $name;
 			}
 		}
-		
+
 		if (count($jobs) === count($equipJobs)) {
 			return array('All Jobs');
 		}
@@ -1235,7 +1235,7 @@ class Flux_Template {
 			return $jobs;
 		}
 	}
-	
+
 	/**
 	 * Link to a monster view page.
 	 *
@@ -1251,7 +1251,7 @@ class Flux_Template {
 			if ($server) {
 				$params['preferred_server'] = $server;
 			}
-			
+
 			$url = $this->url('monster', 'view', $params);
 			return sprintf('<a href="%s" class="link-to-monster">%s</a>', $url, htmlspecialchars($text));
 		}
@@ -1259,7 +1259,7 @@ class Flux_Template {
 			return false;
 		}
 	}
-	
+
 	/**
 	 *
 	 */
@@ -1268,16 +1268,16 @@ class Flux_Template {
 		$locations   = array();
 		$equipLoc    = (int)$equipLoc;
 		$equipLocs   = Flux::getEquipLocationList();
-		
+
 		foreach ($equipLocs as $bit => $name) {
 			if ($equipLoc & $bit) {
 				$locations[] = $name;
 			}
 		}
-		
+
 		return $locations;
 	}
-	
+
 	/**
 	 *
 	 */
@@ -1285,13 +1285,13 @@ class Flux_Template {
 	{
 		$upper   = array();
 		$table   = Flux::getEquipUpperList();
-		
+
 		foreach ($table as $bit => $name) {
 			if ($equipUpper & $bit) {
 				$upper[] = $name;
 			}
 		}
-		
+
 		return $upper;
 	}
 
@@ -1310,7 +1310,7 @@ class Flux_Template {
 			if ($server) {
 				$params['preferred_server'] = $server;
 			}
-			
+
 			$url = $this->url('guild', 'view', $params);
 			return sprintf('<a href="%s" class="link-to-guild">%s</a>', $url, htmlspecialchars($text));
 		}
@@ -1318,7 +1318,7 @@ class Flux_Template {
 			return false;
 		}
 	}
-	
+
 	/**
 	 *
 	 */
@@ -1329,7 +1329,7 @@ class Flux_Template {
 		$button = ob_get_clean();
 		return $button;
 	}
-	
+
 	/**
 	 *
 	 */
@@ -1338,26 +1338,26 @@ class Flux_Template {
 		if (!$serverName) {
 			$serverName = Flux::$sessionData->loginAthenaGroup->serverName;
 		}
-		
+
 		if (!$athenaServerName) {
 			$athenaServerName = Flux::$sessionData->getAthenaServer(Flux::$sessionData->athenaServerName);
 		}
-		
+
 		if (!$serverName || !$athenaServerName) {
 			return false;
 		}
-		
+
 		$dir   = FLUX_DATA_DIR."/itemshop/$serverName/$athenaServerName";
 		$exts  = implode('|', array_map('preg_quote', Flux::config('ShopImageExtensions')->toArray()));
 		$imgs  = glob("$dir/$shopItemID.*");
-		
+
 		if (is_array($imgs)) {
 			$files = preg_grep("/\.($exts)$/", $imgs);
 		}
 		else {
 			$files = array();
 		}
-		
+
 		if (empty($files)) {
 			return false;
 		}
@@ -1367,7 +1367,7 @@ class Flux_Template {
 			return preg_replace('&/{2,}&', '/', "{$this->basePath}/$imageFile");
 		}
 	}
-	
+
 	/**
 	 *
 	 */
@@ -1377,7 +1377,7 @@ class Flux_Template {
 		$link = preg_replace('&/{2,}&', '/', "{$this->basePath}/$path");
 		return file_exists($path) ? $link : false;
 	}
-	
+
 	/**
 	 *
 	 */
@@ -1387,7 +1387,7 @@ class Flux_Template {
 		$link = preg_replace('&/{2,}&', '/', "{$this->basePath}/$path");
 		return file_exists($path) ? $link : false;
 	}
-	
+
  	/**
  	 *
  	 */
@@ -1397,7 +1397,7 @@ class Flux_Template {
 		$link = preg_replace('&/{2,}&', '/', "{$this->basePath}/$path");
 		return file_exists($path) ? $link : false;
 	}
-	
+
 	/**
 	 *
 	 */
@@ -1407,7 +1407,7 @@ class Flux_Template {
 		$link = preg_replace('&/{2,}&', '/', "{$this->basePath}/$path");
 		return file_exists($path) ? $link : false;
 	}
-	
+
 	/**
 	 *
 	 */
@@ -1422,7 +1422,7 @@ class Flux_Template {
 		}
 		return $array;
  	}
-	
+
 	/**
 	 * Return the template name ("default")
 	 * @access public

--- a/modules/cplog/ban.php
+++ b/modules/cplog/ban.php
@@ -10,8 +10,8 @@ $sqlpartial .= "WHERE 1=1 ";
 $sqlpartial .= "AND a.banned_by IS NOT NULL ";
 $bind        = array();
 
-$account     = trim($params->get('account'));
-$bannedBy    = trim($params->get('banned_by'));
+$account     = trim($params->get('account') ?? '');
+$bannedBy    = trim($params->get('banned_by') ?? '');
 $banType     = $params->get('ban_type');
 $banDate     = $params->get('ban_date');
 $banUntil    = $params->get('ban_until_date');

--- a/modules/cplog/changemail.php
+++ b/modules/cplog/changemail.php
@@ -13,12 +13,12 @@ $requestAfter  = $params->get('request_after_date');
 $requestBefore = $params->get('request_before_date');
 $changeAfter   = $params->get('change_after_date');
 $changeBefore  = $params->get('change_before_date');
-$accountID     = trim($params->get('account_id'));
-$username      = trim($params->get('username'));
-$oldEmail      = trim($params->get('old_email'));
-$newEmail      = trim($params->get('new_email'));
-$requestIP     = trim($params->get('request_ip'));
-$changeIP      = trim($params->get('change_ip'));
+$accountID     = trim($params->get('account_id') ?? '');
+$username      = trim($params->get('username') ?? '');
+$oldEmail      = trim($params->get('old_email') ?? '');
+$newEmail      = trim($params->get('new_email') ?? '');
+$requestIP     = trim($params->get('request_ip') ?? '');
+$changeIP      = trim($params->get('change_ip') ?? '');
 
 if ($requestAfter) {
 	$sqlpartial .= 'AND request_date >= ? ';
@@ -60,7 +60,7 @@ $sth->execute($bind);
 $paginator = $this->getPaginator($sth->fetch()->total);
 $paginator->setSortableColumns(array(
 	'log.account_id', 'userid',
-	'change_date' => 'desc', 'change_ip', 
+	'change_date' => 'desc', 'change_ip',
 	'request_date' => 'desc', 'request_ip'
 ));
 

--- a/modules/cplog/changepass.php
+++ b/modules/cplog/changepass.php
@@ -11,9 +11,9 @@ $bind        = array();
 // Password change searching.
 $changeAfter   = $params->get('change_after_date');
 $changeBefore  = $params->get('change_before_date');
-$accountID     = trim($params->get('account_id'));
-$username      = trim($params->get('username'));
-$changeIP      = trim($params->get('change_ip'));
+$accountID     = trim($params->get('account_id') ?? '');
+$username      = trim($params->get('username') ?? '');
+$changeIP      = trim($params->get('change_ip') ?? '');
 
 if ($changeAfter) {
 	$sqlpartial .= 'AND change_date >= ? ';
@@ -40,7 +40,7 @@ if ($auth->allowedToSearchCpChangePass) {
 	$oldPassword = $params->get('old_password');
 	$newPassword = $params->get('new_password');
 	$useMD5      = $session->loginAthenaGroup->loginServer->config->getUseMD5();
-	
+
 	if ($oldPassword) {
 		if ($useMD5) {
 			$oldPassword = md5($oldPassword);

--- a/modules/cplog/ipban.php
+++ b/modules/cplog/ipban.php
@@ -7,8 +7,8 @@ $ipBanTable = Flux::config('FluxTables.IpBanTable');
 $sqlpartial = "WHERE 1=1 ";
 $bind       = array();
 
-$ipAddress   = trim($params->get('ip'));
-$bannedBy    = trim($params->get('banned_by'));
+$ipAddress   = trim($params->get('ip') ?? '');
+$bannedBy    = trim($params->get('banned_by') ?? '');
 $banType     = $params->get('ban_type');
 $banDate     = $params->get('ban_date');
 $banUntil    = $params->get('ban_until_date');

--- a/modules/cplog/login.php
+++ b/modules/cplog/login.php
@@ -9,8 +9,8 @@ $bind          = array();
 
 $password    = $params->get('password');
 $accountID   = (int)$params->get('account_id');
-$username    = trim($params->get('username'));
-$ipAddress   = trim($params->get('ip'));
+$username    = trim($params->get('username') ?? '');
+$ipAddress   = trim($params->get('ip') ?? '');
 $loginAfter  = $params->get('login_after_date');
 $loginBefore = $params->get('login_before_date');
 $errorCode   = $params->get('error_code');

--- a/modules/cplog/paypal.php
+++ b/modules/cplog/paypal.php
@@ -14,10 +14,10 @@ $sqlpartial .= "WHERE (p.server_name = ? OR p.server_name IS NULL OR p.server_na
 $bind            = array($session->loginAthenaGroup->serverName);
 $opMapping       = array('eq' => '=', 'gt' => '>', 'lt' => '<');
 $opValues        = array_keys($opMapping);
-$txnID           = trim($params->get('txn_id'));
-$parentTxnID     = trim($params->get('parent_txn_id'));
-$paymentStatus   = trim($params->get('status'));
-$emailAddress    = trim($params->get('email'));
+$txnID           = trim($params->get('txn_id') ?? '');
+$parentTxnID     = trim($params->get('parent_txn_id') ?? '');
+$paymentStatus   = trim($params->get('status') ?? '');
+$emailAddress    = trim($params->get('email') ?? '');
 $amount          = $params->get('amount');
 $amountOp        = $params->get('amount_op');
 $credits         = $params->get('credits');

--- a/modules/cplog/resetpass.php
+++ b/modules/cplog/resetpass.php
@@ -13,10 +13,10 @@ $requestAfter  = $params->get('request_after_date');
 $requestBefore = $params->get('request_before_date');
 $resetAfter    = $params->get('reset_after_date');
 $resetBefore   = $params->get('reset_before_date');
-$accountID     = trim($params->get('account_id'));
-$username      = trim($params->get('username'));
-$requestIP     = trim($params->get('request_ip'));
-$resetIP       = trim($params->get('reset_ip'));
+$accountID     = trim($params->get('account_id') ?? '');
+$username      = trim($params->get('username') ?? '');
+$requestIP     = trim($params->get('request_ip') ?? '');
+$resetIP       = trim($params->get('reset_ip') ?? '');
 
 if ($requestAfter) {
 	$sqlpartial .= 'AND request_date >= ? ';
@@ -47,7 +47,7 @@ if ($auth->allowedToSearchCpResetPass) {
 	$oldPassword = $params->get('old_password');
 	$newPassword = $params->get('new_password');
 	$useMD5      = $session->loginAthenaGroup->loginServer->config->getUseMD5();
-	
+
 	if ($oldPassword) {
 		if ($useMD5) {
 			$oldPassword = md5($oldPassword);
@@ -71,7 +71,7 @@ $sth->execute($bind);
 $paginator = $this->getPaginator($sth->fetch()->total);
 $paginator->setSortableColumns(array(
 	'log.account_id', 'userid',
-	'reset_date' => 'desc', 'reset_ip', 
+	'reset_date' => 'desc', 'reset_ip',
 	'request_date' => 'desc', 'request_ip'
 ));
 
@@ -82,4 +82,5 @@ $sth  = $server->connection->getStatement($sql);
 $sth->execute($bind);
 
 $resets = $sth->fetchAll();
+
 ?>

--- a/modules/item/index.php
+++ b/modules/item/index.php
@@ -12,13 +12,13 @@ try {
 	$tableName = "{$server->charMapDatabase}.items";
 	$tempTable = new Flux_TemporaryTable($server->connection, $tableName, $fromTables);
 	$shopTable = Flux::config('FluxTables.ItemShopTable');
-	
+
 	// Statement parameters, joins and conditions.
 	$bind        = array();
 	$sqlpartial  = "LEFT OUTER JOIN {$server->charMapDatabase}.$shopTable ON $shopTable.nameid = items.id ";
 	$sqlpartial .= "WHERE 1=1 ";
 	$itemID      = $params->get('item_id');
-	
+
 	if ($itemID) {
 		$sqlpartial .= "AND items.id = ? ";
 		$bind[]      = $itemID;
@@ -48,7 +48,7 @@ try {
 		$refineable   = $params->get('refineable');
 		$forSale      = $params->get('for_sale');
 		$custom       = $params->get('custom');
-		
+
 		if ($itemName) {
 			$sqlpartial .= "AND (name_japanese LIKE ? OR name_japanese = ?) ";
 			$bind[]      = "%$itemName%";
@@ -68,7 +68,7 @@ try {
 				} else {
 					$sqlpartial .= 'AND type IS NULL ';
 				}
-				
+
 				if (count($itemTypeSplit) == 2 && is_numeric($itemType2) && (floatval($itemType2) == intval($itemType2))) {
 					$itemTypes2 = Flux::config('ItemTypes2')->toArray();
 					if (array_key_exists($itemType, $itemTypes2) && array_key_exists($itemType2, $itemTypes2[$itemType]) && $itemTypes2[$itemType][$itemType2]) {
@@ -81,17 +81,17 @@ try {
 			} else {
 				$typeName   = preg_quote($itemType, '/');
 				$itemTypes  = preg_grep("/.*?$typeName.*?/i", Flux::config('ItemTypes')->toArray());
-				
+
 				if (count($itemTypes)) {
 					$itemTypes   = array_keys($itemTypes);
 					$sqlpartial .= "AND (";
 					$partial     = '';
-					
+
 					foreach ($itemTypes as $id) {
 						$partial .= "type = ? OR ";
 						$bind[]   = $id;
 					}
-					
+
 					$partial     = preg_replace('/\s*OR\s*$/', '', $partial);
 					$sqlpartial .= "$partial) ";
 				} else {
@@ -112,14 +112,14 @@ try {
 					}
 				}
 			} else {
-				$combinationName = preg_quote($equipLocs, '/');
+				$combinationName = preg_quote($equipLocs ?? '', '/');
 				$equipLocationCombinations = preg_grep("/.*?$combinationName.*?/i", Flux::config('EquipLocationCombinations')->toArray());
-				
+
 				if (count($equipLocationCombinations)) {
 					$equipLocationCombinations = array_keys($equipLocationCombinations);
 					$sqlpartial .= "AND (";
 					$partial     = '';
-					
+
 					foreach ($equipLocationCombinations as $id) {
 						if ($id === 0) {
 							$partial .= "(equip_locations = 0 OR equip_locations IS NULL) OR ";
@@ -128,13 +128,13 @@ try {
 							$bind[]   = $id;
 						}
 					}
-					
+
 					$partial     = preg_replace('/\s*OR\s*$/', '', $partial);
 					$sqlpartial .= "$partial) ";
 				}
 			}
 		}
-		
+
 		if (in_array($npcBuyOp, $opValues) && trim($npcBuy) != '') {
 			$op = $opMapping[$npcBuyOp];
 			if ($op == '=' && $npcBuy === '0') {
@@ -145,7 +145,7 @@ try {
 				$bind[]      = $npcBuy;
 			}
 		}
-		
+
 		if (in_array($npcSellOp, $opValues) && trim($npcSell) != '') {
 			$op = $opMapping[$npcSellOp];
 			if ($op == '=' && $npcSell === '0') {
@@ -156,7 +156,7 @@ try {
 				$bind[]      = $npcSell;
 			}
 		}
-		
+
 		if (in_array($weightOp, $opValues) && trim($weight) != '') {
 			$op = $opMapping[$weightOp];
 			if ($op == '=' && $weight === '0') {
@@ -167,7 +167,7 @@ try {
 				$bind[]      = $weight;
 			}
 		}
-		
+
 		if (in_array($atkOp, $opValues) && trim($atk) != '') {
 			$op = $opMapping[$atkOp];
 			if ($op == '=' && $atk === '0') {
@@ -178,7 +178,7 @@ try {
 				$bind[]      = $atk;
 			}
 		}
-		
+
 		if (in_array($matkOp, $opValues) && trim($matk) != '') {
 			$op = $opMapping[$matkOp];
 			if ($op == '=' && $matk === '0') {
@@ -189,7 +189,7 @@ try {
 				$bind[]      = $matk;
 			}
 		}
-		
+
 		if (in_array($defenseOp, $opValues) && trim($defense) != '') {
 			$op = $opMapping[$defenseOp];
 			if ($op == '=' && $defense === '0') {
@@ -200,7 +200,7 @@ try {
 				$bind[]      = $defense;
 			}
 		}
-		
+
 		if (in_array($rangeOp, $opValues) && trim($range) != '') {
 			$op = $opMapping[$rangeOp];
 			if ($op == '=' && $range === '0') {
@@ -211,7 +211,7 @@ try {
 				$bind[]      = $range;
 			}
 		}
-		
+
 		if (in_array($slotsOp, $opValues) && trim($slots) != '') {
 			$op = $opMapping[$slotsOp];
 			if ($op == '=' && $slots === '0') {
@@ -222,7 +222,7 @@ try {
 				$bind[]      = $slots;
 			}
 		}
-		
+
 		if ($refineable) {
 			if ($refineable == 'yes') {
 				$sqlpartial .= "AND refineable > 0 ";
@@ -231,7 +231,7 @@ try {
 				$sqlpartial .= "AND IFNULL(refineable, 0) < 1 ";
 			}
 		}
-		
+
 		if ($forSale) {
 			if ($forSale == 'yes') {
 				$sqlpartial .= "AND $shopTable.cost > 0 ";
@@ -240,7 +240,7 @@ try {
 				$sqlpartial .= "AND IFNULL($shopTable.cost, 0) < 1 ";
 			}
 		}
-		
+
 		if ($custom) {
 			if ($custom == 'yes') {
 				$sqlpartial .= "AND origin_table LIKE '%item_db2' ";
@@ -250,31 +250,31 @@ try {
 			}
 		}
 	}
-	
+
 	// Get total count and feed back to the paginator.
 	$sth = $server->connection->getStatement("SELECT COUNT(DISTINCT items.id) AS total FROM $tableName $sqlpartial");
 	$sth->execute($bind);
-	
+
 	$paginator = $this->getPaginator($sth->fetch()->total);
 	$sortable = array(
 		'item_id' => 'asc', 'name', 'type', 'equip_locations', 'price_buy', 'price_sell', 'weight',
 		'atk', 'matk', 'defense', 'range', 'slots', 'refineable', 'cost', 'origin_table'
 	);
 	$paginator->setSortableColumns($sortable);
-	
+
 	$col  = "origin_table, items.id AS item_id, name_japanese AS name, type, ";
 	$col .= "IFNULL(equip_locations, 0) AS equip_locations, price_buy, weight/10 AS weight, ";
 	$col .= "defence AS defense, `range`, slots, refineable, cost, $shopTable.id AS shop_item_id, ";
 	$col .= "IFNULL(price_sell, FLOOR(price_buy/2)) AS price_sell, view_sprite as view, atk, matk";
-	
+
 	$sql  = $paginator->getSQL("SELECT $col FROM $tableName $sqlpartial GROUP BY items.id");
 	$sth  = $server->connection->getStatement($sql);
-	
+
 	$sth->execute($bind);
 	$items = $sth->fetchAll();
-	
+
 	$authorized = $auth->actionAllowed('item', 'view');
-	
+
 	if ($items && count($items) === 1 && $authorized && Flux::config('SingleMatchRedirectItem')) {
 		$this->redirect($this->url('item', 'view', array('id' => $items[0]->item_id)));
 	}
@@ -284,7 +284,7 @@ catch (Exception $e) {
 		// Ensure table gets dropped.
 		$tempTable->drop();
 	}
-	
+
 	// Raise the original exception.
 	$class = get_class($e);
 	throw new $class($e->getMessage());

--- a/modules/logdata/login.php
+++ b/modules/logdata/login.php
@@ -8,10 +8,10 @@ $bind       = array();
 
 $dateAfter  = $params->get('log_after_date');
 $dateBefore = $params->get('log_before_date');
-$ipAddress  = trim($params->get('ip'));
-$username   = trim($params->get('user'));
-$logMessage = trim($params->get('log'));
-$response   = trim($params->get('rcode'));
+$ipAddress  = trim($params->get('ip') ?? '');
+$username   = trim($params->get('user') ?? '');
+$logMessage = trim($params->get('log') ?? '');
+$response   = trim($params->get('rcode') ?? '');
 
 if ($dateAfter) {
 	$sqlpartial .= 'AND time >= ? ';
@@ -65,13 +65,13 @@ if ($logins) {
 	foreach ($logins as $_tmplogin) {
 		$usernames[] = $noCase ? strtolower($_tmplogin->user) : $_tmplogin->user;
 	}
-	
+
 	$uid  = $noCase ? 'LOWER(userid)' : 'userid';
 	$sql  = "SELECT $uid AS userid, account_id FROM {$server->loginDatabase}.login WHERE ";
 	$sql .= "sex != 'S' AND group_id >= 0 AND $uid IN (".implode(',', array_fill(0, count($usernames), '?')).")";
 	$sth  = $server->connection->getStatement($sql);
 	$sth->execute($usernames);
-	
+
 	$data = $sth->fetchAll();
 	if ($data) {
 		$accounts = array();
@@ -79,7 +79,7 @@ if ($logins) {
 			$userid = $noCase ? strtolower($row->userid) : $row->userid;
 			$accounts[$userid] = $row->account_id;
 		}
-		
+
 		foreach ($logins as $_tmplogin) {
 			$userid = $noCase ? strtolower($_tmplogin->user) : $_tmplogin->user;
 			if (array_key_exists($userid, $accounts)) {

--- a/modules/ranking/alchemist.php
+++ b/modules/ranking/alchemist.php
@@ -6,7 +6,7 @@ $alchemistJobs = Flux::config('AlchemistJobClasses')->toArray();
 $jobClass      = $params->get('jobclass');
 $bind          = array();
 
-if (trim($jobClass) === '') {
+if (trim($jobClass ?? '') === '') {
 	$jobClass = null;
 }
 

--- a/modules/ranking/blacksmith.php
+++ b/modules/ranking/blacksmith.php
@@ -6,7 +6,7 @@ $blacksmithJobs = Flux::config('BlacksmithJobClasses')->toArray();
 $jobClass       = $params->get('jobclass');
 $bind           = array();
 
-if (trim($jobClass) === '') {
+if (trim($jobClass ?? '') === '') {
 	$jobClass = null;
 }
 

--- a/modules/ranking/character.php
+++ b/modules/ranking/character.php
@@ -6,7 +6,7 @@ $classes  = Flux::config('JobClasses')->toArray();
 $jobClass = $params->get('jobclass');
 $bind     = array();
 
-if (trim($jobClass) === '') {
+if (trim($jobClass ?? '') === '') {
 	$jobClass = null;
 }
 

--- a/modules/ranking/death.php
+++ b/modules/ranking/death.php
@@ -6,7 +6,7 @@ $classes  = Flux::config('JobClasses')->toArray();
 $jobClass = $params->get('jobclass');
 $bind     = array();
 
-if (trim($jobClass) === '') {
+if (trim($jobClass ?? '') === '') {
 	$jobClass = null;
 }
 

--- a/modules/ranking/zeny.php
+++ b/modules/ranking/zeny.php
@@ -6,7 +6,7 @@ $classes  = Flux::config('JobClasses')->toArray();
 $jobClass = $params->get('jobclass');
 $bind     = array();
 
-if (trim($jobClass) === '') {
+if (trim($jobClass ?? '') === '') {
 	$jobClass = null;
 }
 

--- a/themes/default/account/create.php
+++ b/themes/default/account/create.php
@@ -40,27 +40,27 @@
 			</td>
 		</tr>
 		<?php endif ?>
-		
+
 		<tr>
 			<th><label for="register_username"><?php echo htmlspecialchars(Flux::message('AccountUsernameLabel')) ?></label></th>
-			<td><input type="text" name="username" id="register_username" value="<?php echo htmlspecialchars($params->get('username')) ?>" /></td>
+			<td><input type="text" name="username" id="register_username" value="<?php echo htmlspecialchars($params->get('username') ?? '') ?>" /></td>
 		</tr>
-		
+
 		<tr>
 			<th><label for="register_password"><?php echo htmlspecialchars(Flux::message('AccountPasswordLabel')) ?></label></th>
 			<td><input type="password" name="password" id="register_password" /></td>
 		</tr>
-		
+
 		<tr>
 			<th><label for="register_confirm_password"><?php echo htmlspecialchars(Flux::message('AccountPassConfirmLabel')) ?></label></th>
 			<td><input type="password" name="confirm_password" id="register_confirm_password" /></td>
 		</tr>
-		
+
 		<tr>
 			<th><label for="register_email_address"><?php echo htmlspecialchars(Flux::message('AccountEmailLabel')) ?></label></th>
-			<td><input type="text" name="email_address" id="register_email_address" value="<?php echo htmlspecialchars($params->get('email_address')) ?>" /></td>
+			<td><input type="text" name="email_address" id="register_email_address" value="<?php echo htmlspecialchars($params->get('email_address') ?? '') ?>" /></td>
 		</tr>
-		
+
 		<tr>
 			<th><label><?php echo htmlspecialchars(Flux::message('AccountGenderLabel')) ?></label></th>
 			<td>
@@ -71,12 +71,12 @@
 				</p>
 			</td>
 		</tr>
-		
+
 		<tr>
 			<th><label><?php echo htmlspecialchars(Flux::message('AccountBirthdateLabel')) ?></label></th>
 			<td><?php echo $this->dateField('birthdate',null,0,100) ?></td>
 		</tr>
-		
+
 		<?php if (Flux::config('UseCaptcha')): ?>
 		<tr>
 			<?php if (Flux::config('EnableReCaptcha')): ?>
@@ -88,7 +88,7 @@
 				<div class="security-code">
 					<img src="<?php echo $this->url('captcha') ?>" />
 				</div>
-				
+
 				<input type="text" name="security_code" id="register_security_code" />
 				<div style="font-size: smaller;" class="action">
 					<strong><a href="javascript:refreshSecurityCode('.security-code img')"><?php echo htmlspecialchars(Flux::message('RefreshSecurityCode')) ?></a></strong>
@@ -97,7 +97,7 @@
 			<?php endif ?>
 		</tr>
 		<?php endif ?>
-		
+
 		<tr>
 			<td></td>
 			<td>

--- a/themes/default/account/index.php
+++ b/themes/default/account/index.php
@@ -5,21 +5,21 @@
 	<?php echo $this->moduleActionFormInputs($params->get('module')) ?>
 	<p>
 		<label for="account_id"><?php echo htmlspecialchars(Flux::message('AccountIdLabel')) ?>:</label>
-		<input type="text" name="account_id" id="account_id" value="<?php echo htmlspecialchars($params->get('account_id')) ?>" />
+		<input type="text" name="account_id" id="account_id" value="<?php echo htmlspecialchars($params->get('account_id') ?? '') ?>" />
 		...
 		<label for="username"><?php echo htmlspecialchars(Flux::message('UsernameLabel')) ?>:</label>
-		<input type="text" name="username" id="username" value="<?php echo htmlspecialchars($params->get('username')) ?>" />
+		<input type="text" name="username" id="username" value="<?php echo htmlspecialchars($params->get('username') ?? '') ?>" />
 		<?php if ($searchPassword): ?>
 		...
 		<label for="password"><?php echo htmlspecialchars(Flux::message('PasswordLabel')) ?>:</label>
-		<input type="text" name="password" id="password" value="<?php echo htmlspecialchars($params->get('password')) ?>" />
+		<input type="text" name="password" id="password" value="<?php echo htmlspecialchars($params->get('password') ?? '') ?>" />
 		<?php endif ?>
 		...
 		<label for="email"><?php echo htmlspecialchars(Flux::message('EmailAddressLabel')) ?>:</label>
-		<input type="text" name="email" id="email" value="<?php echo htmlspecialchars($params->get('email')) ?>" />
+		<input type="text" name="email" id="email" value="<?php echo htmlspecialchars($params->get('email') ?? '') ?>" />
 		...
 		<label for="last_ip"><?php echo htmlspecialchars(Flux::message('LastUsedIpLabel')) ?>:</label>
-		<input type="text" name="last_ip" id="last_ip" value="<?php echo htmlspecialchars($params->get('last_ip')) ?>" />
+		<input type="text" name="last_ip" id="last_ip" value="<?php echo htmlspecialchars($params->get('last_ip') ?? '') ?>" />
 		...
 		<label for="gender"><?php echo htmlspecialchars(Flux::message('GenderLabel')) ?>:</label>
 		<select name="gender" id="gender">
@@ -44,7 +44,7 @@
 			<option value="gt"<?php if ($account_group_id_op == 'gt') echo ' selected="selected"' ?>><?php echo htmlspecialchars(Flux::message('IsGreaterThanLabel')) ?></option>
 			<option value="lt"<?php if ($account_group_id_op == 'lt') echo ' selected="selected"' ?>><?php echo htmlspecialchars(Flux::message('IsLessThanLabel')) ?></option>
 		</select>
-		<input type="text" name="account_group_id" id="account_group_id" value="<?php echo htmlspecialchars($params->get('account_group_id')) ?>" />
+		<input type="text" name="account_group_id" id="account_group_id" value="<?php echo htmlspecialchars($params->get('account_group_id') ?? '') ?>" />
 		...
 		<label for="balance"><?php echo htmlspecialchars(Flux::message('CreditBalanceLabel')) ?>:</label>
 		<select name="balance_op">
@@ -52,7 +52,7 @@
 			<option value="gt"<?php if ($balance_op == 'gt') echo ' selected="selected"' ?>><?php echo htmlspecialchars(Flux::message('IsGreaterThanLabel')) ?></option>
 			<option value="lt"<?php if ($balance_op == 'lt') echo ' selected="selected"' ?>><?php echo htmlspecialchars(Flux::message('IsLessThanLabel')) ?></option>
 		</select>
-		<input type="text" name="balance" id="balance" value="<?php echo htmlspecialchars($params->get('balance')) ?>" />
+		<input type="text" name="balance" id="balance" value="<?php echo htmlspecialchars($params->get('balance') ?? '') ?>" />
 	</p>
 	<p>
 		<label for="logincount"><?php echo htmlspecialchars(Flux::message('LoginCountLabel')) ?>:</label>
@@ -61,7 +61,7 @@
 			<option value="gt"<?php if ($logincount_op == 'gt') echo ' selected="selected"' ?>><?php echo htmlspecialchars(Flux::message('IsGreaterThanLabel')) ?></option>
 			<option value="lt"<?php if ($logincount_op == 'lt') echo ' selected="selected"' ?>><?php echo htmlspecialchars(Flux::message('IsLessThanLabel')) ?></option>
 		</select>
-		<input type="text" name="logincount" id="logincount" value="<?php echo htmlspecialchars($params->get('logincount')) ?>" />
+		<input type="text" name="logincount" id="logincount" value="<?php echo htmlspecialchars($params->get('logincount') ?? '') ?>" />
 		...
 		<label for="use_birthdate_after"><?php echo htmlspecialchars(Flux::message('BirthdateBetweenLabel')) ?>:</label>
 		<input type="checkbox" name="use_birthdate_after" id="use_birthdate_after"<?php if ($params->get('use_birthdate_after')) echo ' checked="checked"' ?> />
@@ -76,8 +76,8 @@
 		<?php echo $this->dateField('last_login_after') ?>
 		<label for="use_last_login_before">&mdash;</label>
 		<input type="checkbox" name="use_last_login_before" id="use_last_login_before"<?php if ($params->get('use_last_login_before')) echo ' checked="checked"' ?> />
-		<?php echo $this->dateField('last_login_before') ?>		
-		
+		<?php echo $this->dateField('last_login_before') ?>
+
 		<input type="submit" value="<?php echo htmlspecialchars(Flux::message('SearchButton')) ?>" />
 		<input type="button" value="<?php echo htmlspecialchars(Flux::message('ResetButton')) ?>" onclick="reload()" />
 	</p>

--- a/themes/default/account/login.php
+++ b/themes/default/account/login.php
@@ -16,7 +16,7 @@
 	<table class="generic-form-table">
 		<tr>
 			<th><label for="login_username"><?php echo htmlspecialchars(Flux::message('AccountUsernameLabel')) ?></label></th>
-			<td><input type="text" name="username" id="login_username" value="<?php echo htmlspecialchars($params->get('username')) ?>" /></td>
+			<td><input type="text" name="username" id="login_username" value="<?php echo htmlspecialchars($params->get('username') ?? '') ?>" /></td>
 		</tr>
 		<tr>
 			<th><label for="login_password"><?php echo htmlspecialchars(Flux::message('AccountPasswordLabel')) ?></label></th>

--- a/themes/default/character/online.php
+++ b/themes/default/character/online.php
@@ -7,13 +7,13 @@
 		<?php echo $this->moduleActionFormInputs($params->get('module'), $params->get('action')) ?>
 		<p>
 			<label for="char_name">Character Name:</label>
-			<input type="text" name="char_name" id="char_name" value="<?php echo htmlspecialchars($params->get('char_name')) ?>" />
+			<input type="text" name="char_name" id="char_name" value="<?php echo htmlspecialchars($params->get('char_name') ?? '') ?>" />
 			...
 			<label for="char_class">Job Class:</label>
-			<input type="text" name="char_class" id="char_class" value="<?php echo htmlspecialchars($params->get('char_class')) ?>" />
+			<input type="text" name="char_class" id="char_class" value="<?php echo htmlspecialchars($params->get('char_class') ?? '') ?>" />
 			...
 			<label for="guild_name">Guild:</label>
-			<input type="text" name="guild_name" id="guild_name" value="<?php echo htmlspecialchars($params->get('guild_name')) ?>" />
+			<input type="text" name="guild_name" id="guild_name" value="<?php echo htmlspecialchars($params->get('guild_name') ?? '') ?>" />
 
 			<input type="submit" value="Search" />
 			<input type="button" value="Reset" onclick="reload()" />
@@ -66,7 +66,7 @@
 		<?php else: ?>
 			<td colspan="2"><span class="not-applicable">None</span></td>
 		<?php endif ?>
-		
+
 		<td>
 		<?php if (!$char->hidemap && $auth->allowedToViewOnlinePosition): ?>
 			<?php echo htmlspecialchars(basename($char->last_map, '.gat')) ?>

--- a/themes/default/cplog/ban.php
+++ b/themes/default/cplog/ban.php
@@ -5,10 +5,10 @@
 	<?php echo $this->moduleActionFormInputs($params->get('module'), $params->get('action')) ?>
 	<p>
 		<label for="account">Account:</label>
-		<input type="text" name="account" id="account" value="<?php echo htmlspecialchars($params->get('account')) ?>" />
+		<input type="text" name="account" id="account" value="<?php echo htmlspecialchars($params->get('account') ?? '') ?>" />
 		...
 		<label for="banned_by">Banned By:</label>
-		<input type="text" name="banned_by" id="banned_by" value="<?php echo htmlspecialchars($params->get('banned_by')) ?>" />
+		<input type="text" name="banned_by" id="banned_by" value="<?php echo htmlspecialchars($params->get('banned_by') ?? '') ?>" />
 		...
 		<label for="ban_type">Ban Type:</label>
 		<select name="ban_type" id="ban_type">

--- a/themes/default/cplog/changemail.php
+++ b/themes/default/cplog/changemail.php
@@ -21,24 +21,24 @@
 	</p>
 	<p>
 		<label for="account_id">Account ID:</label>
-		<input type="text" name="account_id" id="account_id" value="<?php echo htmlspecialchars($params->get('account_id')) ?>" />
+		<input type="text" name="account_id" id="account_id" value="<?php echo htmlspecialchars($params->get('account_id') ?? '') ?>" />
 		...
 		<label for="username">Username:</label>
-		<input type="text" name="username" id="username" value="<?php echo htmlspecialchars($params->get('username')) ?>" />
+		<input type="text" name="username" id="username" value="<?php echo htmlspecialchars($params->get('username') ?? '') ?>" />
 		...
 		<label for="request_ip">Request IP:</label>
-		<input type="text" name="request_ip" id="request_ip" value="<?php echo htmlspecialchars($params->get('request_ip')) ?>" />
+		<input type="text" name="request_ip" id="request_ip" value="<?php echo htmlspecialchars($params->get('request_ip') ?? '') ?>" />
 		...
 		<label for="change_ip">Change IP:</label>
-		<input type="text" name="change_ip" id="change_ip" value="<?php echo htmlspecialchars($params->get('change_ip')) ?>" />
+		<input type="text" name="change_ip" id="change_ip" value="<?php echo htmlspecialchars($params->get('change_ip') ?? '') ?>" />
 	</p>
 	<p>
 		<label for="old_email">Old Email:</label>
-		<input type="text" name="old_email" id="old_email" value="<?php echo htmlspecialchars($params->get('old_email')) ?>" />
+		<input type="text" name="old_email" id="old_email" value="<?php echo htmlspecialchars($params->get('old_email') ?? '') ?>" />
 		...
 		<label for="new_email">New Email:</label>
-		<input type="text" name="new_email" id="new_email" value="<?php echo htmlspecialchars($params->get('new_email')) ?>" />
-		
+		<input type="text" name="new_email" id="new_email" value="<?php echo htmlspecialchars($params->get('new_email') ?? '') ?>" />
+
 		<input type="submit" value="Search" />
 		<input type="button" value="Reset" onclick="reload()" />
 	</p>

--- a/themes/default/cplog/changepass.php
+++ b/themes/default/cplog/changepass.php
@@ -13,14 +13,14 @@
 	</p>
 	<p>
 		<label for="account_id">Account ID:</label>
-		<input type="text" name="account_id" id="account_id" value="<?php echo htmlspecialchars($params->get('account_id')) ?>" />
+		<input type="text" name="account_id" id="account_id" value="<?php echo htmlspecialchars($params->get('account_id') ?? '') ?>" />
 		...
 		<label for="username">Username:</label>
-		<input type="text" name="username" id="username" value="<?php echo htmlspecialchars($params->get('username')) ?>" />
+		<input type="text" name="username" id="username" value="<?php echo htmlspecialchars($params->get('username') ?? '') ?>" />
 		...
 		<label for="change_ip">Change IP:</label>
-		<input type="text" name="change_ip" id="change_ip" value="<?php echo htmlspecialchars($params->get('change_ip')) ?>" />
-		
+		<input type="text" name="change_ip" id="change_ip" value="<?php echo htmlspecialchars($params->get('change_ip') ?? '') ?>" />
+
 		<?php if (!$auth->allowedToSearchCpChangePass): ?>
 		<input type="submit" value="Search" />
 		<input type="button" value="Reset" onclick="reload()" />
@@ -33,7 +33,7 @@
 		...
 		<label for="new_password">New Password:</label>
 		<input type="text" name="new_password" id="new_password" value="<?php echo htmlspecialchars($params->get('new_password')) ?>" />
-		
+
 		<input type="submit" value="Search" />
 		<input type="button" value="Reset" onclick="reload()" />
 	</p>

--- a/themes/default/cplog/ipban.php
+++ b/themes/default/cplog/ipban.php
@@ -5,10 +5,10 @@
 	<?php echo $this->moduleActionFormInputs($params->get('module'), $params->get('action')) ?>
 	<p>
 		<label for="ip">IP Address:</label>
-		<input type="text" name="ip" id="ip" value="<?php echo htmlspecialchars($params->get('ip')) ?>" />
+		<input type="text" name="ip" id="ip" value="<?php echo htmlspecialchars($params->get('ip') ?? '') ?>" />
 		...
 		<label for="banned_by">Banned By:</label>
-		<input type="text" name="banned_by" id="banned_by" value="<?php echo htmlspecialchars($params->get('banned_by')) ?>" />
+		<input type="text" name="banned_by" id="banned_by" value="<?php echo htmlspecialchars($params->get('banned_by') ?? '') ?>" />
 		...
 		<label for="ban_type">Ban Type:</label>
 		<select name="ban_type" id="ban_type">

--- a/themes/default/cplog/login.php
+++ b/themes/default/cplog/login.php
@@ -18,23 +18,23 @@
 	</p>
 	<p>
 		<label for="account_id">Account ID:</label>
-		<input type="text" name="account_id" id="account_id" value="<?php echo htmlspecialchars($params->get('account_id')) ?>" />
+		<input type="text" name="account_id" id="account_id" value="<?php echo htmlspecialchars($params->get('account_id') ?? '') ?>" />
 		...
 		<label for="username">Username:</label>
-		<input type="text" name="username" id="username" value="<?php echo htmlspecialchars($params->get('username')) ?>" />
+		<input type="text" name="username" id="username" value="<?php echo htmlspecialchars($params->get('username') ?? '') ?>" />
 		...
 		<label for="ip">IP Address:</label>
-		<input type="text" name="ip" id="ip" value="<?php echo htmlspecialchars($params->get('ip')) ?>" />
+		<input type="text" name="ip" id="ip" value="<?php echo htmlspecialchars($params->get('ip') ?? '') ?>" />
 		...
 		<label for="error_code">Error Code:</label>
 		<select name="error_code" id="error_code">
 			<option value="all"<?php if (is_null($params->get('error_code')) || strtolower($params->get('error_code') == 'all')) echo ' selected="selected"' ?>>All</option>
-			<option value="none"<?php if (strtolower($params->get('error_code')) == 'none') echo ' selected="selected"' ?>>None</option>
+			<option value="none"<?php if (strtolower($params->get('error_code') ?? '') == 'none') echo ' selected="selected"' ?>>None</option>
 		<?php foreach ($loginErrors->toArray() as $errorCode => $errorType): ?>
-			<option value="<?php echo $errorCode ?>"<?php if (ctype_digit($params->get('error_code')) && $params->get('error_code') == $errorCode) echo ' selected="selected"' ?>><?php echo htmlspecialchars($errorType) ?></option>
+			<option value="<?php echo $errorCode ?>"<?php if (ctype_digit($params->get('error_code') ?? '') && $params->get('error_code') == $errorCode) echo ' selected="selected"' ?>><?php echo htmlspecialchars($errorType) ?></option>
 		<?php endforeach ?>
 		</select>
-		
+
 		<input type="submit" value="Search" />
 		<input type="button" value="Reset" onclick="reload()" />
 	</p>

--- a/themes/default/cplog/paypal.php
+++ b/themes/default/cplog/paypal.php
@@ -5,16 +5,16 @@
 	<?php echo $this->moduleActionFormInputs($params->get('module'), $params->get('action')) ?>
 	<p>
 		<label for="txn_id">Transaction ID:</label>
-		<input type="text" name="txn_id" id="txn_id" value="<?php echo htmlspecialchars($params->get('txn_id')) ?>" />
+		<input type="text" name="txn_id" id="txn_id" value="<?php echo htmlspecialchars($params->get('txn_id') ?? '') ?>" />
 		...
 		<label for="parent_txn_id">Parent Transaction ID:</label>
-		<input type="text" name="parent_txn_id" id="parent_txn_id" value="<?php echo htmlspecialchars($params->get('parent_txn_id')) ?>" />
+		<input type="text" name="parent_txn_id" id="parent_txn_id" value="<?php echo htmlspecialchars($params->get('parent_txn_id') ?? '') ?>" />
 		...
 		<label for="status">Status:</label>
-		<input type="text" name="status" id="status" value="<?php echo htmlspecialchars($params->get('status')) ?>" />
+		<input type="text" name="status" id="status" value="<?php echo htmlspecialchars($params->get('status') ?? '') ?>" />
 		...
 		<label for="email">E-mail:</label>
-		<input type="text" name="email" id="email" value="<?php echo htmlspecialchars($params->get('email')) ?>" />
+		<input type="text" name="email" id="email" value="<?php echo htmlspecialchars($params->get('email') ?? '') ?>" />
 	</p>
 	<p>
 		<label for="amount">Amount:</label>
@@ -23,7 +23,7 @@
 			<option value="gt"<?php if ($amount_op == 'gt') echo ' selected="selected"' ?>>is greater than</option>
 			<option value="lt"<?php if ($amount_op == 'lt') echo ' selected="selected"' ?>>is less than</option>
 		</select>
-		<input type="text" name="amount" id="amount" value="<?php echo htmlspecialchars($params->get('amount')) ?>" />
+		<input type="text" name="amount" id="amount" value="<?php echo htmlspecialchars($params->get('amount') ?? '') ?>" />
 		...
 		<label for="credits">Credits:</label>
 		<select name="credits_op">
@@ -31,10 +31,10 @@
 			<option value="gt"<?php if ($credits_op == 'gt') echo ' selected="selected"' ?>>is greater than</option>
 			<option value="lt"<?php if ($credits_op == 'lt') echo ' selected="selected"' ?>>is less than</option>
 		</select>
-		<input type="text" name="credits" id="credits" value="<?php echo htmlspecialchars($params->get('credits')) ?>" />
+		<input type="text" name="credits" id="credits" value="<?php echo htmlspecialchars($params->get('credits') ?? '') ?>" />
 		...
 		<label for="account">Account:</label>
-		<input type="text" name="account" id="account" value="<?php echo htmlspecialchars($params->get('account')) ?>" />
+		<input type="text" name="account" id="account" value="<?php echo htmlspecialchars($params->get('account') ?? '') ?>" />
 	</p>
 	<p>
 		<label for="use_processed_after">Process Date Between:</label>
@@ -51,7 +51,7 @@
 		<label for="use_received_before">&mdash;</label>
 		<input type="checkbox" name="use_received_before" id="use_received_before"<?php if ($params->get('use_received_before')) echo ' checked="checked"' ?> />
 		<?php echo $this->dateField('received_before') ?>
-		
+
 		<input type="submit" value="Search" />
 		<input type="button" value="Reset" onclick="reload()" />
 	</p>

--- a/themes/default/cplog/resetpass.php
+++ b/themes/default/cplog/resetpass.php
@@ -21,17 +21,17 @@
 	</p>
 	<p>
 		<label for="account_id">Account ID:</label>
-		<input type="text" name="account_id" id="account_id" value="<?php echo htmlspecialchars($params->get('account_id')) ?>" />
+		<input type="text" name="account_id" id="account_id" value="<?php echo htmlspecialchars($params->get('account_id') ?? '') ?>" />
 		...
 		<label for="username">Username:</label>
-		<input type="text" name="username" id="username" value="<?php echo htmlspecialchars($params->get('username')) ?>" />
+		<input type="text" name="username" id="username" value="<?php echo htmlspecialchars($params->get('username') ?? '') ?>" />
 		...
 		<label for="request_ip">Request IP:</label>
-		<input type="text" name="request_ip" id="request_ip" value="<?php echo htmlspecialchars($params->get('request_ip')) ?>" />
+		<input type="text" name="request_ip" id="request_ip" value="<?php echo htmlspecialchars($params->get('request_ip') ?? '') ?>" />
 		...
 		<label for="reset_ip">Reset IP:</label>
-		<input type="text" name="reset_ip" id="reset_ip" value="<?php echo htmlspecialchars($params->get('reset_ip')) ?>" />
-		
+		<input type="text" name="reset_ip" id="reset_ip" value="<?php echo htmlspecialchars($params->get('reset_ip') ?? '') ?>" />
+
 		<?php if (!$auth->allowedToSearchCpResetPass): ?>
 		<input type="submit" value="Search" />
 		<input type="button" value="Reset" onclick="reload()" />
@@ -44,7 +44,7 @@
 		...
 		<label for="new_password">New Password:</label>
 		<input type="text" name="new_password" id="new_password" value="<?php echo htmlspecialchars($params->get('new_password')) ?>" />
-		
+
 		<input type="submit" value="Search" />
 		<input type="button" value="Reset" onclick="reload()" />
 	</p>

--- a/themes/default/ipban/add.php
+++ b/themes/default/ipban/add.php
@@ -9,13 +9,13 @@
 	<table class="generic-form-table">
 		<tr>
 			<th><label for="list"><?php echo htmlspecialchars(Flux::message('IpbanIpAddressLabel')) ?></label></th>
-			<td><input type="text" name="list" id="list" value="<?php echo htmlspecialchars($params->get('list')) ?>" /></td>
+			<td><input type="text" name="list" id="list" value="<?php echo htmlspecialchars($params->get('list') ?? '') ?>" /></td>
 			<td><p><?php echo htmlspecialchars(Flux::message('IpbanIpAddressInfo')) ?></p></td>
 		</tr>
 		<tr>
 			<th><label for="reason"><?php echo htmlspecialchars(Flux::message('IpbanReasonLabel')) ?></label></th>
 			<td>
-				<textarea name="reason" id="reason" class="reason"><?php echo htmlspecialchars($params->get('reason')) ?></textarea>
+				<textarea name="reason" id="reason" class="reason"><?php echo htmlspecialchars($params->get('reason') ?? '') ?></textarea>
 			</td>
 			<td></td>
 		</tr>

--- a/themes/default/ipban/edit.php
+++ b/themes/default/ipban/edit.php
@@ -16,7 +16,7 @@
 				<td><p><?php echo htmlspecialchars(Flux::message('IpbanIpAddressInfo')) ?></p></td>
 			</tr>
 			<tr>
-				<th><label for="reason"><?php echo htmlspecialchars(Flux::message('IpbanReasonLabel')) ?></label></th>
+				<th><label for="reason"><?php echo htmlspecialchars(Flux::message('IpbanEditReasonLabel')) ?></label></th>
 				<td>
 					<textarea name="reason" id="reason" class="reason"><?php
 						echo htmlspecialchars(($reason=$params->get('reason')) ? $reason : $ipban->reason)

--- a/themes/default/item/add.php
+++ b/themes/default/item/add.php
@@ -11,13 +11,13 @@
 	<table class="vertical-table">
 		<tr>
 			<th><label for="item_id">Item ID</label></th>
-			<td><input type="text" name="item_id" id="item_id" value="<?php echo htmlspecialchars($itemID) ?>" /></td>
+			<td><input type="text" name="item_id" id="item_id" value="<?php echo htmlspecialchars($itemID ?? '') ?>" /></td>
 			<th><label for="view">View ID</label></th>
-			<td><input type="text" name="view" id="view" value="<?php echo htmlspecialchars($viewID) ?>" /></td>
+			<td><input type="text" name="view" id="view" value="<?php echo htmlspecialchars($viewID ?? '') ?>" /></td>
 		</tr>
 		<tr>
 			<th><label for="name_english">Identifier</label></th>
-			<td><input type="text" name="name_english" id="name_english" value="<?php echo htmlspecialchars($identifier) ?>" /></td>
+			<td><input type="text" name="name_english" id="name_english" value="<?php echo htmlspecialchars($identifier ?? '') ?>" /></td>
 			<th><label for="type">Type</label></th>
 			<td>
 				<select name="type" id="type">
@@ -31,7 +31,7 @@
 		</tr>
 		<tr>
 			<th><label for="name_japanese">Name</label></th>
-			<td><input type="text" name="name_japanese" id="name_japanese" value="<?php echo htmlspecialchars($itemName) ?>" /></td>
+			<td><input type="text" name="name_japanese" id="name_japanese" value="<?php echo htmlspecialchars($itemName ?? '') ?>" /></td>
 			<th><label for="slots">Slots</label></th>
 			<td><input type="text" name="slots" id="slots" value="<?php echo htmlspecialchars($slots) ?>" /></td>
 		</tr>

--- a/themes/default/item/edit.php
+++ b/themes/default/item/edit.php
@@ -76,7 +76,7 @@
 			<th><label for="matk">MATK</label></th>
 			<td><input type="text" name="matk" id="matk" value="<?php echo htmlspecialchars($matk) ?>" /></td>
 			<th><label for="equip_level_max">Max Equip Level</label></th>
-			<td><input type="text" name="equip_level_max" id="equip_level_max" value="<?php echo htmlspecialchars($equipLevelMax) ?>" /></td>
+			<td><input type="text" name="equip_level_max" id="equip_level_max" value="<?php echo htmlspecialchars($equipLevelMax ?? '') ?>" /></td>
 		</tr>
 		<tr>
 			<th><label>Refineable</label></th>

--- a/themes/default/item/index.php
+++ b/themes/default/item/index.php
@@ -5,10 +5,10 @@
 	<?php echo $this->moduleActionFormInputs($params->get('module')) ?>
 	<p>
 		<label for="item_id">Item ID:</label>
-		<input type="text" name="item_id" id="item_id" value="<?php echo htmlspecialchars($params->get('item_id')) ?>" />
+		<input type="text" name="item_id" id="item_id" value="<?php echo htmlspecialchars($params->get('item_id') ?? '') ?>" />
 		...
 		<label for="name">Name:</label>
-		<input type="text" name="name" id="name" value="<?php echo htmlspecialchars($params->get('name')) ?>" />
+		<input type="text" name="name" id="name" value="<?php echo htmlspecialchars($params->get('name') ?? '') ?>" />
 		...
 		<label for="type">Type:</label>
 		<select name="type">
@@ -17,7 +17,7 @@
 			</option>
 			<?php foreach (Flux::config('ItemTypes')->toArray() as $typeId => $typeName): ?>
 				<option value="<?php echo $typeId ?>"<?php if (($type=$params->get('type')) === strval($typeId)) echo ' selected="selected"' ?>>
-					<?php echo htmlspecialchars($typeName) ?>
+					<?php echo htmlspecialchars($typeName ?? '') ?>
 				</option>
 				<?php $itemTypes2 = Flux::config('ItemTypes2')->toArray() ?>
 				<?php if (array_key_exists($typeId, $itemTypes2)): ?>
@@ -37,7 +37,7 @@
 			</option>
 			<?php foreach (Flux::config('EquipLocationCombinations')->toArray() as $locId => $locName): ?>
 				<option value="<?php echo $locId ?>"<?php if (($equip_loc=$params->get('equip_loc')) === strval($locId)) echo ' selected="selected"' ?>>
-					<?php echo htmlspecialchars($locName) ?>
+					<?php echo htmlspecialchars($locName ?? '') ?>
 				</option>
 			<?php endforeach ?>
 		</select>
@@ -49,7 +49,7 @@
 			<option value="gt"<?php if ($npc_buy_op == 'gt') echo ' selected="selected"' ?>>is greater than</option>
 			<option value="lt"<?php if ($npc_buy_op == 'lt') echo ' selected="selected"' ?>>is less than</option>
 		</select>
-		<input type="text" name="npc_buy" id="npc_buy" value="<?php echo htmlspecialchars($params->get('npc_buy')) ?>" />
+		<input type="text" name="npc_buy" id="npc_buy" value="<?php echo htmlspecialchars($params->get('npc_buy') ?? '') ?>" />
 		...
 		<label for="npc_sell">NPC Sell:</label>
 		<select name="npc_sell_op">
@@ -57,7 +57,7 @@
 			<option value="gt"<?php if ($npc_sell_op == 'gt') echo ' selected="selected"' ?>>is greater than</option>
 			<option value="lt"<?php if ($npc_sell_op == 'lt') echo ' selected="selected"' ?>>is less than</option>
 		</select>
-		<input type="text" name="npc_sell" id="npc_sell" value="<?php echo htmlspecialchars($params->get('npc_sell')) ?>" />
+		<input type="text" name="npc_sell" id="npc_sell" value="<?php echo htmlspecialchars($params->get('npc_sell') ?? '') ?>" />
 		...
 		<label for="weight">Weight:</label>
 		<select name="weight_op">
@@ -65,7 +65,7 @@
 			<option value="gt"<?php if ($weight_op == 'gt') echo ' selected="selected"' ?>>is greater than</option>
 			<option value="lt"<?php if ($weight_op == 'lt') echo ' selected="selected"' ?>>is less than</option>
 		</select>
-		<input type="text" name="weight" id="weight" value="<?php echo htmlspecialchars($params->get('weight')) ?>" />
+		<input type="text" name="weight" id="weight" value="<?php echo htmlspecialchars($params->get('weight') ?? '') ?>" />
 	</p>
 	<p>
 		<label for="range">Range:</label>
@@ -74,7 +74,7 @@
 			<option value="gt"<?php if ($range_op == 'gt') echo ' selected="selected"' ?>>is greater than</option>
 			<option value="lt"<?php if ($range_op == 'lt') echo ' selected="selected"' ?>>is less than</option>
 		</select>
-		<input type="text" name="range" id="range" value="<?php echo htmlspecialchars($params->get('range')) ?>" />
+		<input type="text" name="range" id="range" value="<?php echo htmlspecialchars($params->get('range') ?? '') ?>" />
 		...
 		<label for="slots">Slots:</label>
 		<select name="slots_op">
@@ -82,7 +82,7 @@
 			<option value="gt"<?php if ($slots_op == 'gt') echo ' selected="selected"' ?>>is greater than</option>
 			<option value="lt"<?php if ($slots_op == 'lt') echo ' selected="selected"' ?>>is less than</option>
 		</select>
-		<input type="text" name="slots" id="slots" value="<?php echo htmlspecialchars($params->get('slots')) ?>" />
+		<input type="text" name="slots" id="slots" value="<?php echo htmlspecialchars($params->get('slots') ?? '') ?>" />
 		...
 		<label for="defense">Defense:</label>
 		<select name="defense_op">
@@ -90,7 +90,7 @@
 			<option value="gt"<?php if ($defense_op == 'gt') echo ' selected="selected"' ?>>is greater than</option>
 			<option value="lt"<?php if ($defense_op == 'lt') echo ' selected="selected"' ?>>is less than</option>
 		</select>
-		<input type="text" name="defense" id="defense" value="<?php echo htmlspecialchars($params->get('defense')) ?>" />
+		<input type="text" name="defense" id="defense" value="<?php echo htmlspecialchars($params->get('defense') ?? '') ?>" />
 	</p>
 	<p>
 		<label for="atk">ATK:</label>
@@ -99,7 +99,7 @@
 			<option value="gt"<?php if ($atk_op == 'gt') echo ' selected="selected"' ?>>is greater than</option>
 			<option value="lt"<?php if ($atk_op == 'lt') echo ' selected="selected"' ?>>is less than</option>
 		</select>
-		<input type="text" name="atk" id="atk" value="<?php echo htmlspecialchars($params->get('atk')) ?>" />
+		<input type="text" name="atk" id="atk" value="<?php echo htmlspecialchars($params->get('atk') ?? '') ?>" />
 		...
 		<label for="matk">MATK:</label>
 		<select name="matk_op">
@@ -107,7 +107,7 @@
 			<option value="gt"<?php if ($matk_op == 'gt') echo ' selected="selected"' ?>>is greater than</option>
 			<option value="lt"<?php if ($matk_op == 'lt') echo ' selected="selected"' ?>>is less than</option>
 		</select>
-		<input type="text" name="matk" id="matk" value="<?php echo htmlspecialchars($params->get('matk')) ?>" />
+		<input type="text" name="matk" id="matk" value="<?php echo htmlspecialchars($params->get('matk') ?? '') ?>" />
 		...
 		<label for="refineable">Refineable:</label>
 		<select name="refineable" id="refineable">

--- a/themes/default/logdata/login.php
+++ b/themes/default/logdata/login.php
@@ -13,17 +13,17 @@
 	</p>
 	<p>
 		<label for="ip">IP Address:</label>
-		<input type="text" name="ip" id="ip" value="<?php echo htmlspecialchars($params->get('ip')) ?>" />
+		<input type="text" name="ip" id="ip" value="<?php echo htmlspecialchars($params->get('ip') ?? '') ?>" />
 		...
 		<label for="user">Username:</label>
-		<input type="text" name="user" id="user" value="<?php echo htmlspecialchars($params->get('user')) ?>" />
+		<input type="text" name="user" id="user" value="<?php echo htmlspecialchars($params->get('user') ?? '') ?>" />
 		...
 		<label for="log">Log Message:</label>
-		<input type="text" name="log" id="log" value="<?php echo htmlspecialchars($params->get('log')) ?>" />
+		<input type="text" name="log" id="log" value="<?php echo htmlspecialchars($params->get('log') ?? '') ?>" />
 		...
 		<label for="rcode">Response:</label>
-		<input type="text" name="rcode" id="rcode" value="<?php echo htmlspecialchars($params->get('rcode')) ?>" />
-		
+		<input type="text" name="rcode" id="rcode" value="<?php echo htmlspecialchars($params->get('rcode') ?? '') ?>" />
+
 		<input type="submit" value="Search" />
 		<input type="button" value="Reset" onclick="reload()" />
 	</p>

--- a/themes/default/monster/index.php
+++ b/themes/default/monster/index.php
@@ -5,14 +5,14 @@
 	<?php echo $this->moduleActionFormInputs($params->get('module')) ?>
 	<p>
 		<label for="monster_id">Monster ID:</label>
-		<input type="text" name="monster_id" id="monster_id" value="<?php echo htmlspecialchars($params->get('monster_id')) ?>" />
+		<input type="text" name="monster_id" id="monster_id" value="<?php echo htmlspecialchars($params->get('monster_id') ?? '') ?>" />
 		...
 		<label for="name">Name:</label>
-		<input type="text" name="name" id="name" value="<?php echo htmlspecialchars($params->get('name')) ?>" />
+		<input type="text" name="name" id="name" value="<?php echo htmlspecialchars($params->get('name') ?? '') ?>" />
 		...
 		<label for="mvp">MVP:</label>
 		<select name="mvp" id="mvp">
-			<option value="all"<?php if (!($mvpParam=strtolower($params->get('mvp'))) || $mvpParam == 'all') echo ' selected="selected"' ?>>All</option>
+			<option value="all"<?php if (!($mvpParam=strtolower($params->get('mvp') ?? '')) || $mvpParam == 'all') echo ' selected="selected"' ?>>All</option>
 			<option value="yes"<?php if ($mvpParam == 'yes') echo ' selected="selected"' ?>>Yes</option>
 			<option value="no"<?php if ($mvpParam == 'no') echo ' selected="selected"' ?>>No</option>
 		</select>
@@ -61,7 +61,7 @@
 	</p>
 	<p>
 		<label for="card_id">Card ID:</label>
-		<input type="text" name="card_id" id="card_id" value="<?php echo htmlspecialchars($params->get('card_id')) ?>" />
+		<input type="text" name="card_id" id="card_id" value="<?php echo htmlspecialchars($params->get('card_id') ?? '') ?>" />
 		...
 		<label for="custom">Custom:</label>
 		<select name="custom" id="custom">
@@ -69,7 +69,7 @@
 			<option value="yes"<?php if ($custom == 'yes') echo ' selected="selected"' ?>>Yes</option>
 			<option value="no"<?php if ($custom == 'no') echo ' selected="selected"' ?>>No</option>
 		</select>
-		
+
 		<input type="submit" value="Search" />
 		<input type="button" value="Reset" onclick="reload()" />
 	</p>

--- a/themes/default/monster/view.php
+++ b/themes/default/monster/view.php
@@ -35,7 +35,7 @@
 		<th>iRO Name</th>
 		<td><?php echo htmlspecialchars($monster->iro_name) ?></td>
 		<th>HP</th>
-		<td><?php echo number_format($monster->hp) ?></td>
+		<td><?php echo number_format($monster->hp ?? 0) ?></td>
 	</tr>
 	<tr>
 		<th>Size</th>
@@ -47,7 +47,7 @@
 			<?php endif ?>
 		</td>
 		<th>SP</th>
-		<td><?php echo number_format($monster->sp) ?></td>
+		<td><?php echo number_format($monster->sp ?? 0) ?></td>
 	</tr>
 	<tr>
 		<th>Race</th>
@@ -56,7 +56,7 @@
 				<?php echo htmlspecialchars($race) ?>
 			<?php else: ?>
 				<span class="not-applicable">Unknown</span>
-			<?php endif ?>	
+			<?php endif ?>
 		</td>
 		<th>Level</th>
 		<td><?php echo number_format($monster->level) ?></td>
@@ -99,7 +99,7 @@
 	</tr>
 	<tr>
 		<th>Delay Motion</th>
-		<td><?php echo number_format($monster->defense_motion) ?> ms</td>
+		<td><?php echo number_format($monster->defense_motion ?? 0) ?> ms</td>
 		<th>Vision Range</th>
 		<td><?php echo number_format($monster->range3) ?></td>
 	</tr>
@@ -204,7 +204,7 @@
 		<th>Target</th>
 		<th>Condition</th>
 		<th>Value</th>
-	</tr>	
+	</tr>
 	<?php foreach ($mobSkills as $skill): ?>
 	<tr>
 		<td><?php echo htmlspecialchars($skill->INFO) ?></td>


### PR DESCRIPTION
fix(compatibility): resolve deprecated notices and warnings for PHP 8.x+

- Replaced deprecated function calls and adjusted code to comply with modern PHP standards.
- Addressed various warnings related to optional parameters and null type declarations.
- Refactored equipJobsToArray() for clarity and compatibility.
- Unnecessary indentation and trailing whitespace were removed across multiple files.

docs(readme): updated README with installation guide and PHP requirements

- Added a basic installation guide to README.md.
- Updated minimum PHP version to 7.0 due to usage of the null coalescing - operator (??).
- Improved formatting and documentation consistency.

BREAKING CHANGE: Requires PHP >= 7.0.